### PR TITLE
Fix liquid syntax errors in node_modules

### DIFF
--- a/.jekyllignore
+++ b/.jekyllignore
@@ -1,0 +1,8 @@
+OrganizeMe/node_modules/
+node_modules/
+vendor/
+**/node_modules/**
+OrganizeMe/node_modules/
+node_modules/
+vendor/
+**/node_modules/**

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,6 @@
+exclude:
+  - OrganizeMe/node_modules/
+  - node_modules/
+  - vendor/
+  - "**/node_modules/**"
+


### PR DESCRIPTION
Exclude `node_modules` directories from Jekyll build to resolve Liquid syntax errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-5df323db-9cc9-4826-856c-5b05990fbe25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5df323db-9cc9-4826-856c-5b05990fbe25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

